### PR TITLE
Prevent scrolling on mouse wheel input

### DIFF
--- a/index.js
+++ b/index.js
@@ -340,6 +340,7 @@ function getCanvas(){
     }
 
     function scrollEventHandler(e){
+	e.preventDefault();
 	const toCenter = vec3.create();
 	vec3.subtract(toCenter, gameState.currentEyeCenter, gameState.eyePos);
 	vec3.scale(toCenter, toCenter, e.deltaY * 0.001);


### PR DESCRIPTION
Currently, when the user scales the graphics using the mouse wheel, the whole page scrolls. This PR addresses this issue by preventing the page from scrolling on mouse wheel input. The user can still scroll the page by moving the cursor outside of the canvas and scrolling normally.